### PR TITLE
Pax 4487 update actions with versions using node24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,22 +13,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
     - name: Set up JDK 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 #v5.0.0
       with:
         java-version: '17'
         distribution: 'temurin'
         cache: gradle
 
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 #v5.0.0
 
     - name: Build with Gradle
       run: ./gradlew build
       
     - name: Upload APK
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f #v6.0.0
       with:
         name: app
         path: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,26 +9,26 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
-    - name: Set up JDK 17
-      uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 #v5.0.0
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        cache: gradle
+      - name: Checkout project
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 #v5.0.0
+      - name: Set up JAVA 17
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 #v5.0.0
+        with:
+          java-version: '17'
+          distribution: 'corretto'
 
-    - name: Build with Gradle
-      run: ./gradlew build
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 #v5.0.0
+
+      - name: Build with Gradle
+        run: ./gradlew build
       
-    - name: Upload APK
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f #v6.0.0
-      with:
-        name: app
-        path: app/build/outputs/apk/debug/app-debug.apk
+      - name: Upload APK
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f #v6.0.0
+        with:
+          name: app
+          path: app/build/outputs/apk/debug/app-debug.apk

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,7 @@
 junit = "4.13.2"
 assertk = "0.28.1"
 activity_compose = "1.12.2"
-material3 = "latest.release"
-compose_bom = "2026.01.00"
+compose_bom = "2026.05.00"
 core_ktx = "1.17.0"
 lifecycle_ktx = "2.10.0"
 serialization_json = "1.10.0"
@@ -20,7 +19,7 @@ androidx_ui_tooling = { module = "androidx.compose.ui:ui-tooling" }
 
 # Main Implementation Dependencies
 androidx_activity_compose = { module = "androidx.activity:activity-compose", version.ref = "activity_compose" }
-androidx_material3 = { module = "androidx.compose.material3:material3", version.ref = "material3" }
+androidx_material3 = { module = "androidx.compose.material3:material3" }
 androidx_ui = { module = "androidx.compose.ui:ui" }
 androidx_ui_graphics = { module = "androidx.compose.ui:ui-graphics" }
 androidx_ui_tooling_preview = { module = "androidx.compose.ui:ui-tooling-preview" }


### PR DESCRIPTION
Updates GitHub Actions to using pinned full length commit SHAs
(Versions supporting Node.js 24).

Some compose dependencies needed updates due to failure in the CI.
